### PR TITLE
Feature/event dispatcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,6 @@ This repository contains Aspose Cloud SDK for PHP source code. This SDK allows y
 
 ##What's included in this SDK repository?
 
-###Code
-
 <table>
 <tr>
 <th>Module</th>
@@ -67,20 +65,72 @@ This repository contains Aspose Cloud SDK for PHP source code. This SDK allows y
 
 
 
-###Data
+### Data
 
 In order to manipulate any files, you first need to upload them to the Aspose Cloud storage using Storage module. 
 
-###Output
+### Output
 
 The Aspose Cloud SDK for PHP allows you to save the output files at your specified location.
 
+Make use of the EventDispatcher
+-------------------------------
 
-###Docs
+The SDK allows you to alter the calls made by [connecting `EventListeners`](http://symfony.com/doc/current/components/event_dispatcher/introduction.html#connecting-listeners). You can simply register a php callable in your code by using the following example:
+
+```php
+use Aspose\Cloud\Common\AsposeApp;
+use Aspose\Cloud\Event\ProcessCommandEvent;
+
+$dispatcher = AsposeApp::getEventDispatcher();
+$dispatcher->addListener(ProcessCommandEvent::PRE_CURL, function (ProcessCommandEvent $event) {
+    // will be executed when the ProcessCommandEvent::PRE_CURL event is dispatched
+    curl_setopt($event->getSession(), CURLOPT_TIMEOUT, 60); 
+});
+```
+
+The SDK currenlty dispatches the following events. Please use the Event class constants in your code to register to the specific events.
+
+<table>
+<tr>
+<th>Module</th>
+<th>Event names</th>
+<th>Description</th>
+</tr>
+
+<tr>
+<td>Utils</td>
+<td>ProcessCommandEvent::PRE_CURL</td>
+<td>Allows you to alter the curl session before the call is executed.</td>
+</tr>
+
+<tr>
+<td>Utils</td>
+<td>ProcessCommandEvent::POST_CURL</td>
+<td>Allows you to alter the curl session and response after the curl request is executed, but before the curl session is closed.</td>
+</tr>
+
+<tr>
+<td>Utils</td>
+<td>ValidateOutputEvent::VALIDATE_OUTPUT</td>
+<td>Allows you to add extra validation on the result, by altering the invalid variable.</td>
+</tr>
+
+<tr>
+<td>Pdf & Document</td>
+<td>SplitPageEvent::PAGE_IS_SPLIT</td>
+<td>Triggers after a SDK split call, for each page that was split. This allows you to use the `$outputFile` and `$pageNumber` directly after it was saved by `Utils::saveFile`.</td>
+</tr>
+
+</table>
+
+Docs
+----
 
 For SDK related help, please go through [wiki](https://github.com/asposeforcloud/Aspose_Cloud_SDK_For_PHP/wiki).
 For Aspose Cloud APIs related help, please go through [Aspose.Total for Cloud](http://www.aspose.com/cloud/total-api.aspx).
 
-##Start a Free Trial Today
+Start a Free Trial Today
+------------------------
 
 Start a free trial today – all you need is to [sign up](https://cloud.aspose.com/SignUp) with Aspose for Cloud service. Once you have signed up, you are ready to try powerful file processing features offered by Aspose for Cloud.

--- a/composer.json
+++ b/composer.json
@@ -1,4 +1,3 @@
-
 {
     "description": 	"This repository contains Aspose Cloud SDK for PHP source code. Aspose Cloud SDK for PHP lets PHP developers convert and process a variety of file formats in the cloud quickly and easily.",
     "name": 		"aspose/cloud-sdk-php",
@@ -13,7 +12,8 @@
     ],
     "require": {
         "php": ">=5.3.2",
-        "ext-curl": "*"
+        "ext-curl": "*",
+        "symfony/event-dispatcher": ">=2.0"
     },
     "autoload": {
         "psr-0": {

--- a/src/Aspose/Cloud/Common/AsposeApp.php
+++ b/src/Aspose/Cloud/Common/AsposeApp.php
@@ -6,6 +6,9 @@
  */
 namespace Aspose\Cloud\Common;
 
+use Symfony\Component\EventDispatcher\EventDispatcher;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+
 class AsposeApp
 {
 
@@ -28,6 +31,11 @@ class AsposeApp
      * @var bool
      */
     public static $debug = false;
+
+    /**
+     * @var EventDispatcherInterface
+     */
+    private static $eventDispatcher;
 
     /**
      * @return string
@@ -96,4 +104,30 @@ class AsposeApp
         self::$debug = $debug;
     }
 
+    /**
+     * @return EventDispatcherInterface
+     */
+    public static function getEventDispatcher()
+    {
+        if (null !== self::$eventDispatcher) {
+            return self::$eventDispatcher;
+        }
+        self::$eventDispatcher = new EventDispatcher();
+    }
+
+    /**
+     * @param EventDispatcherInterface $eventDispatcher
+     */
+    public static function setEventDispatcher($eventDispatcher)
+    {
+        self::$eventDispatcher = $eventDispatcher;
+    }
+
+    /**
+     * @return bool
+     */
+    public static function hasEventDispatcher()
+    {
+        return (null !== self::$eventDispatcher);
+    }
 }

--- a/src/Aspose/Cloud/Event/AbstractEvent.php
+++ b/src/Aspose/Cloud/Event/AbstractEvent.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Aspose\Cloud\Event;
+
+use Symfony\Component\EventDispatcher\Event;
+
+abstract class AbstractEvent extends Event
+{
+
+}

--- a/src/Aspose/Cloud/Event/ProcessCommandEvent.php
+++ b/src/Aspose/Cloud/Event/ProcessCommandEvent.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Aspose\Cloud\Event;
+
+class ProcessCommandEvent extends AbstractEvent
+{
+    const PRE_CURL = 'aspose.utils.pre_curl';
+    const POST_CURL = 'aspose.utils.post_curl';
+
+    /**
+     * @var curl handle
+     */
+    private $session;
+
+    /**
+     * This value will be set during the POST_CURL event
+     * @var string
+     */
+    private $result;
+
+
+    function __construct($session, $result=null)
+    {
+        $this->session = $session;
+        $this->result = $result;
+    }
+
+    /**
+     * @return string
+     */
+    public function getResult()
+    {
+        return $this->result;
+    }
+
+    /**
+     * @param string $result
+     */
+    public function setResult($result)
+    {
+        $this->result = $result;
+    }
+
+    /**
+     * @return curl handle
+     */
+    public function getSession()
+    {
+        return $this->session;
+    }
+
+    /**
+     * @param curl handle $session
+     */
+    public function setSession($session)
+    {
+        $this->session = $session;
+    }
+
+}

--- a/src/Aspose/Cloud/Event/SplitPageEvent.php
+++ b/src/Aspose/Cloud/Event/SplitPageEvent.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Aspose\Cloud\Event;
+
+use Aspose\Cloud\Exception\AsposeCloudException;
+
+class SplitPageEvent extends AbstractEvent
+{
+    /**
+     * Will trigger when a specific page number is split and Utils::saveFile was completed
+     */
+    const PAGE_IS_SPLIT = 'aspose.sdk.page_is_split';
+
+    /**
+     * @var string with absolute path to file
+     */
+    private $outputFile;
+
+    /**
+     * @var integer
+     */
+    private $pageNumber;
+
+
+    function __construct($outputFile, $pageNumber=null)
+    {
+        $this->outputFile = $outputFile;
+        $this->pageNumber = $pageNumber;
+    }
+
+    /**
+     * @return string
+     */
+    public function getOutputFile()
+    {
+        return $this->outputFile;
+    }
+
+    /**
+     * @param string $outputFile
+     */
+    public function setOutputFile($outputFile)
+    {
+        $this->outputFile = $outputFile;
+    }
+
+    /**
+     * @return int
+     */
+    public function getPageNumber()
+    {
+        if (null === $this->pageNumber) {
+            throw new AsposeCloudException('PageNumber is not set for this event.');
+        }
+        return $this->pageNumber;
+    }
+
+    /**
+     * @param int $pageNumber
+     */
+    public function setPageNumber($pageNumber)
+    {
+        $this->pageNumber = $pageNumber;
+    }
+
+}

--- a/src/Aspose/Cloud/Event/ValidateOutputEvent.php
+++ b/src/Aspose/Cloud/Event/ValidateOutputEvent.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Aspose\Cloud\Event;
+
+class ValidateOutputEvent extends AbstractEvent
+{
+    const VALIDATE_OUTPUT = 'aspose.utils.validate_output';
+
+    /**
+     * This value will be set during the POST_CURL event
+     * @var string
+     */
+    private $result;
+
+    /**
+     * @var bool
+     */
+    private $invalid;
+
+
+    function __construct($result, $invalid)
+    {
+        $this->result = $result;
+        $this->invalid = $invalid;
+    }
+
+    /**
+     * @return string
+     */
+    public function getResult()
+    {
+        return $this->result;
+    }
+
+    /**
+     * @param string $result
+     */
+    public function setResult($result)
+    {
+        $this->result = $result;
+    }
+
+    /**
+     * @return boolean
+     */
+    public function isInvalid()
+    {
+        return $this->invalid;
+    }
+
+    /**
+     * @param boolean $invalid
+     */
+    public function setInvalid($invalid)
+    {
+        $this->invalid = $invalid;
+    }
+
+}

--- a/src/Aspose/Cloud/Pdf/Document.php
+++ b/src/Aspose/Cloud/Pdf/Document.php
@@ -7,6 +7,7 @@ namespace Aspose\Cloud\Pdf;
 use Aspose\Cloud\Common\AsposeApp;
 use Aspose\Cloud\Common\Product;
 use Aspose\Cloud\Common\Utils;
+use Aspose\Cloud\Event\SplitPageEvent;
 use Aspose\Cloud\Exception\AsposeCloudException as Exception;
 use Aspose\Cloud\Storage\Folder;
 
@@ -583,22 +584,30 @@ class Document
      */
     public function splitAllPages()
     {
-
         $strURI = Product::$baseProductUri . '/pdf/' . $this->getFileName() . '/split';
         $signedURI = Utils::sign($strURI);
         $responseStream = Utils::processCommand($signedURI, 'POST', '', '');
         $json = json_decode($responseStream);
-        $i = 1;
+
+        $dispatcher = AsposeApp::getEventDispatcher();
+
+        $pageNumber = 1;
         foreach ($json->Result->Documents as $splitPage) {
             $splitFileName = basename($splitPage->Href);
             $strURI = Product::$baseProductUri . '/storage/file/' . $splitFileName;
             $signedURI = Utils::sign($strURI);
             $responseStream = Utils::processCommand($signedURI, 'GET', '', '');
-            $fileName = $this->getFileName() . '_' . $i . '.pdf';
+
+            $fileName = $this->getFileName() . '_' . $pageNumber . '.pdf';
             $outputFile = AsposeApp::$outPutLocation . $fileName;
+
             Utils::saveFile($responseStream, $outputFile);
-            echo $outputFile . '<br />';
-            $i++;
+            echo $outputFile . '<br />'; // FIXME what is the function of this, why let the API echo?
+
+            $event = new SplitPageEvent($outputFile, $pageNumber);
+            $dispatcher->dispatch(SplitPageEvent::PAGE_IS_SPLIT, $event);
+
+            $pageNumber++;
         }
     }
 
@@ -618,17 +627,26 @@ class Document
         $signedURI = Utils::sign($strURI);
         $responseStream = Utils::processCommand($signedURI, 'POST', '', '');
         $json = json_decode($responseStream);
-        $i = 1;
+
+        $dispatcher = AsposeApp::getEventDispatcher();
+
+        $pageNumber = 1;
         foreach ($json->Result->Documents as $splitPage) {
             $splitFileName = basename($splitPage->Href);
             $strURI = Product::$baseProductUri . '/storage/file/' . $splitFileName;
             $signedURI = Utils::sign($strURI);
             $responseStream = Utils::processCommand($signedURI, 'GET', '', '');
-            $fileName = $this->getFileName() . '_' . $i . '.pdf';
+
+            $fileName = $this->getFileName() . '_' . $pageNumber . '.pdf';
             $outputFile = AsposeApp::$outPutLocation . $fileName;
+
             Utils::saveFile($responseStream, $outputFile);
             echo $outputFile . '<br />';
-            $i++;
+
+            $event = new SplitPageEvent($outputFile, $pageNumber);
+            $dispatcher->dispatch(SplitPageEvent::PAGE_IS_SPLIT, $event);
+
+            $pageNumber++;
         }
     }
 
@@ -648,17 +666,26 @@ class Document
         $signedURI = Utils::sign($strURI);
         $responseStream = Utils::processCommand($signedURI, 'POST', '', '');
         $json = json_decode($responseStream);
-        $i = 1;
+
+        $dispatcher = AsposeApp::getEventDispatcher();
+
+        $pageNumber = 1;
         foreach ($json->Result->Documents as $splitPage) {
             $splitFileName = basename($splitPage->Href);
             $strURI = Product::$baseProductUri . '/storage/file/' . $splitFileName;
             $signedURI = Utils::sign($strURI);
             $responseStream = Utils::processCommand($signedURI, 'GET', '', '');
-            $fileName = $this->getFileName() . '_' . $i . '.' . $format;
+
+            $fileName = $this->getFileName() . '_' . $pageNumber . '.' . $format;
             $outputFile = AsposeApp::$outPutLocation . $fileName;
+
             Utils::saveFile($responseStream, $outputFile);
             echo $outputFile . '<br />';
-            $i++;
+
+            $event = new SplitPageEvent($outputFile, $pageNumber);
+            $dispatcher->dispatch(SplitPageEvent::PAGE_IS_SPLIT, $event);
+
+            $pageNumber++;
         }
     }
 

--- a/src/Aspose/Cloud/Slides/Document.php
+++ b/src/Aspose/Cloud/Slides/Document.php
@@ -179,7 +179,6 @@ class Document
 
         $json = json_decode($responseStream);
 
-
         if ($json->Code == 200) {
             foreach ($json->SplitResult->Slides as $splitPage) {
                 $splitFileName = basename($splitPage->Href);

--- a/src/Aspose/Cloud/Words/Document.php
+++ b/src/Aspose/Cloud/Words/Document.php
@@ -7,6 +7,7 @@ namespace Aspose\Cloud\Words;
 use Aspose\Cloud\Common\AsposeApp;
 use Aspose\Cloud\Common\Utils;
 use Aspose\Cloud\Common\Product;
+use Aspose\Cloud\Event\SplitPageEvent;
 use Aspose\Cloud\Storage\Folder;
 use Aspose\Cloud\Exception\AsposeCloudException as Exception;
 
@@ -161,7 +162,9 @@ class Document {
         $json = json_decode($responseStream);
 
         if ($json->Code == 200) {
-            foreach ($json->SplitResult->Pages as $splitPage) {
+
+            $dispatcher = AsposeApp::getEventDispatcher();
+            foreach ($json->SplitResult->Pages as $pageNumber => $splitPage) {
                 $splitFileName = basename($splitPage->Href);
 
                 //build URI to download split slides
@@ -169,9 +172,13 @@ class Document {
                 //sign URI
                 $signedURI = Utils::Sign($strURI);
                 $responseStream = Utils::processCommand($signedURI, "GET", "", "");
+
                 //save split slides
                 $outputFile = AsposeApp::$outPutLocation . $splitFileName;
                 Utils::saveFile($responseStream, $outputFile);
+
+                $event = new SplitPageEvent($outputFile, $pageNumber +1);
+                $dispatcher->dispatch(SplitPageEvent::PAGE_IS_SPLIT, $event);
             }
         }
         else


### PR DESCRIPTION
Without breaking Backwards Compatibility, adding the EventDispatcher will enable you to alter the way how an API call is executed. Extra information about the events that are added can be found in README.md.

This PR allows me to do the following:

```php

$newImageLocation = '/tmp/path/to/new/image/%s.png';

$dispatcher->addListener(
    SplitPageEvent::PAGE_IS_SPLIT,
    function(SplitPageEvent $event) {
        rename(
            $event->getOutputFile(), sprintf($newImageLocation, $event->getPageNumber())
        );
});

$asposeWordsDocument->setFileName($fileName)
     ->splitDocument('', '', 'png')
;
```

Without the event listener I will have to keep waiting when the entire `splitDocument` call is completed, before I can move the images.

Important: please also release tag `0.1` after merging this PR, because `AsposeSymfony` [does rely on `0.1`](https://github.com/asposeforcloud/asposesymfony/blob/master/composer.json) in order to set the `EventDispatcher` directly from the service call.