### PR TITLE
Support 'includeComments'

### DIFF
--- a/src/Aspose/Cloud/Words/Document.php
+++ b/src/Aspose/Cloud/Words/Document.php
@@ -122,9 +122,11 @@ class Document {
      * words should be added to the word count.
      *
      * Make sure the boolean options are strings, (e.g. true should be 'true').
+     * 
+     * @link http://www.aspose.com/docs/display/wordscloud/statistics
      *
      * @param array $options
-     * @return bool|object
+     * @return null|object
      * @throws Exception
      */
     public function getStats(array $options = array())
@@ -135,7 +137,7 @@ class Document {
                 'includeTextInShapes' => 'true',
             ))
             ->setDefined(array(
-                'includeFootnotes',
+                'includeFootnotes', 'includeComments',
             ))
         ;
         $options = $resolver->resolve($options);


### PR DESCRIPTION
The documentation seems to support another parameter, the `includeComments` parameter. See http://www.aspose.com/docs/display/wordscloud/statistics

Please also create a new release