### PR TITLE
Throw AsposeCurlException on cURL error, instead of empty messag

### DIFF
--- a/src/Aspose/Cloud/Exception/AsposeCurlException.php
+++ b/src/Aspose/Cloud/Exception/AsposeCurlException.php
@@ -1,0 +1,24 @@
+<?php
+
+/**
+ * This file is part of the Aspose for Cloud SDK.
+ *
+ * @author Imran Anwar <imran.anwar@Aspose.com>
+ * @author Assad Mahmood <assadvirgo@gmail.com>
+ * @author Rvanlaak <rvanlaak@gmail.com>
+ */
+
+namespace Aspose\Cloud\Exception;
+
+class AsposeCurlException extends AsposeCloudException
+{
+    public $curlHeaders;
+
+    public function __construct($message, $curlHeaders, $code = 0, \Exception $previous = null)
+    {
+        parent::__construct($message, $code, $previous);
+
+        $this->curlHeaders = $curlHeaders;
+    }
+
+}


### PR DESCRIPTION
The API response message now is empty, so the regular `AsposeCloudException` does not tell anything. 

We want to set a cURL timeout so need the cURL error codes and headers, this PR throws a different sort of exception with the required data.

Please merge and create new release asap.

ping @muhammad-ijaz @imranrafique @imranwar @asposeforcloud 